### PR TITLE
Inline int.floor_div and int.modulo

### DIFF
--- a/src/rada/date.gleam
+++ b/src/rada/date.gleam
@@ -1631,18 +1631,30 @@ fn pad_signed_int(value: Int, length: Int) -> String {
   prefix <> suffix
 }
 
-fn floor_div(a: Int, b: Int) -> Int {
-  int.floor_divide(a, b)
-  // We know we're not calling this with b == 0 so the unwrap value will not be used
-  |> result.unwrap(0)
+/// This is the implementation of int.floor_divide but unwrapped with the knowledge
+/// that the divisor is never zero
+fn floor_div(dividend: Int, divisor: Int) -> Int {
+  case
+    { { dividend > 0 && divisor < 0 } || { dividend < 0 && divisor > 0 } }
+    && dividend % divisor != 0
+  {
+    True -> dividend / divisor - 1
+    False -> dividend / divisor
+  }
 }
 
 fn div_with_remainder(a: Int, b: Int) -> #(Int, Int) {
   #(floor_div(a, b), modulo_unwrap(a, b))
 }
 
-fn modulo_unwrap(a: Int, b: Int) -> Int {
-  int.modulo(a, b) |> result.unwrap(0)
+/// This is the implementation of int.modulo but unwrapped with the knowledge that the
+/// the divisor is never zero in our calculations
+fn modulo_unwrap(dividend: Int, divisor: Int) -> Int {
+  let remainder = dividend % divisor
+  case { remainder > 0 && divisor < 0 } || { remainder < 0 && divisor > 0 } {
+    True -> remainder + divisor
+    False -> remainder
+  }
 }
 
 fn is_between_int(value: Int, lower: Int, upper: Int) -> Bool {

--- a/test/rada/testing.gleam
+++ b/test/rada/testing.gleam
@@ -1,9 +1,6 @@
 //// Module of helper functions and types duplicated from within the main date implementation
 //// because we don't want to expose them publicly but want to use them in tests.
 
-import gleam/int
-import gleam/result
-
 import rada/date.{type Month, type Weekday}
 
 pub type CalendarDate {
@@ -45,6 +42,12 @@ fn is_leap_year(year: Int) -> Bool {
   || modulo_unwrap(year, 400) == 0
 }
 
-fn modulo_unwrap(a: Int, b: Int) -> Int {
-  int.modulo(a, b) |> result.unwrap(0)
+/// This is the implementation of int.modulo but unwrapped with the knowledge that the
+/// the divisor is never zero in our calculations
+fn modulo_unwrap(dividend: Int, divisor: Int) -> Int {
+  let remainder = dividend % divisor
+  case { remainder > 0 && divisor < 0 } || { remainder < 0 && divisor > 0 } {
+    True -> remainder + divisor
+    False -> remainder
+  }
 }


### PR DESCRIPTION
With the information we have (that the divisor is never zero) we can do a slightly more optimized approach than the standard library can.

I'm not sure what the difference is and I should really benchmark them but it was flagged by date operations being quite expensive in a real work project which was doing a lot of calculations with dates.

I've also changed from doing 'a * b < 0' to see if either a or b is less than zero (but not the other) to doing the comparisons explicitly as I perhaps incorrectly feel like it would be few CPU cycles.